### PR TITLE
feat: namespace-scoped sprite generation in CI

### DIFF
--- a/.github/workflows/generate-sprites.yml
+++ b/.github/workflows/generate-sprites.yml
@@ -1,0 +1,46 @@
+name: Generate sprites
+
+on:
+  pull_request:
+    paths:
+      - "sprite_assets/**"
+
+concurrency:
+  group: sprites-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  generate:
+    runs-on: ubuntu-latest
+    if: github.actor != 'github-actions[bot]'
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          fetch-depth: 0
+
+      - name: Detect changed namespaces
+        id: namespaces
+        run: |
+          git fetch origin "$GITHUB_BASE_REF" --depth=1
+          CHANGED=$(git diff --name-only "origin/$GITHUB_BASE_REF...HEAD" -- 'sprite_assets/' \
+            | awk -F/ 'NF>=2 {print $2}' | sort -u | tr '\n' ' ' | xargs)
+          echo "changed=$CHANGED" >> "$GITHUB_OUTPUT"
+
+      - name: Generate sprites for changed namespaces
+        if: steps.namespaces.outputs.changed != ''
+        run: bash generate_sprites.sh ${{ steps.namespaces.outputs.changed }}
+
+      - name: Commit regenerated sprites
+        if: steps.namespaces.outputs.changed != ''
+        run: |
+          if [[ -n $(git status --porcelain generated_sprites) ]]; then
+            git config user.name 'github-actions[bot]'
+            git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+            git add generated_sprites
+            git commit -m "chore: regenerate sprites for ${{ steps.namespaces.outputs.changed }}"
+            git push
+          fi

--- a/README.md
+++ b/README.md
@@ -13,3 +13,10 @@
    bash generate_sprites.sh
    ```
    After the run completes, the updated sprites should be available inside the `generated_sprites` folder.
+
+   You can also pass one or more namespace names to only regenerate specific orgs:
+   ```sh
+   bash generate_sprites.sh AtB FRAM
+   ```
+
+> **CI:** When a pull request touches files under `sprite_assets/`, GitHub Actions automatically regenerates sprites for the changed namespaces and commits the result back to the PR branch. No manual script run needed.

--- a/generate_sprites.sh
+++ b/generate_sprites.sh
@@ -8,14 +8,18 @@ OUT_BASE="./generated_sprites"
 THEMES=("light" "dark")
 RESOLUTIONS=("" "@2x")
 
-# Discover namespaces from folder structure
-echo "📂 Scanning sprite_assets for namespaces..."
-NAMESPACES=()
-for dir in sprite_assets/*/; do
-  [ -d "$dir" ] && NAMESPACES+=("$(basename "$dir")")
-done
-
-echo "🔍 Found namespaces: ${NAMESPACES[*]}"
+# Accept optional namespace args; default to all discovered namespaces
+if [[ $# -gt 0 ]]; then
+  NAMESPACES=("$@")
+  echo "🔍 Using provided namespaces: ${NAMESPACES[*]}"
+else
+  echo "📂 Scanning sprite_assets for namespaces..."
+  NAMESPACES=()
+  for dir in sprite_assets/*/; do
+    [ -d "$dir" ] && NAMESPACES+=("$(basename "$dir")")
+  done
+  echo "🔍 Found namespaces: ${NAMESPACES[*]}"
+fi
 
 # 1. Stop & remove existing container
 echo "🔄 Stopping and removing any existing 'martin' container..."
@@ -42,7 +46,6 @@ done
 DOCKER_CMD=(
   docker run -d
   --name martin
-  --restart unless-stopped
   -p 3000:3000
   "${VOLUME_ARGS[@]}"
   ghcr.io/maplibre/martin:v0.13.0
@@ -60,7 +63,10 @@ echo "🚀 Starting 'martin' container..."
 
 # 6. Wait for it to boot up
 echo "⏳ Waiting for martin to initialize..."
-sleep 2
+for i in {1..30}; do
+  curl -sf http://localhost:3000/health >/dev/null && break
+  sleep 1
+done
 
 # 7. Download sprite files
 echo "⬇️ Downloading sprite images (.png and .json)..."
@@ -76,7 +82,7 @@ for NAME in "${NAMESPACES[@]}"; do
         OUTPUT="${OUT_DIR}/${FILENAME}"
 
         echo "  ➤ Downloading ${URL}"
-        curl -sf -o "${OUTPUT}" "${URL}" || echo "⚠️  Failed to download: ${URL}"
+        curl -sf -o "${OUTPUT}" "${URL}"
       done
     done
   done


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/generate-sprites.yml` — triggers on PRs touching `sprite_assets/**`, detects changed namespaces from diff, runs `generate_sprites.sh <namespaces>`, auto-commits regenerated sprites back to PR branch
- Updates `generate_sprites.sh` to accept optional namespace args (zero args = all namespaces, preserves local dev flow)
- Hardens script: replaces `sleep 2` with martin `/health` poll, drops `--restart unless-stopped`, makes curl failures hard errors

Closes AtB-AS/kundevendt#23228

## Test plan

- [x] Open a separate draft PR that edits one SVG under `sprite_assets/Troms/` — confirm workflow triggers, detects only `Troms`, bot commits only `generated_sprites/Troms/` changes
- [x] Edit SVGs in two namespaces — confirm both regenerated, others untouched
- [x] Confirm second workflow run (triggered by bot commit) exits as no-op