### PR TITLE
feat: sprite upload script with versioning and CI generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,21 @@
    ```
 
 > **CI:** When a pull request touches files under `sprite_assets/`, GitHub Actions automatically regenerates sprites for the changed namespaces and commits the result back to the PR branch. No manual script run needed.
+
+3. **Upload sprites to GCS**
+
+   Pre-requisites:
+   - `gcloud` CLI installed and authenticated: `gcloud auth application-default login`
+   - Your account needs `roles/storage.objectAdmin` on the target `*--shared-assets` buckets.
+
+   ```sh
+   bash upload_sprites.sh staging   # upload to all staging buckets
+   bash upload_sprites.sh prod      # upload to all prod buckets
+   ```
+
+   Each run:
+   - Bumps the version automatically (reads last version from `uploads.md`, increments)
+   - Uploads all four tenants (AtB, Troms, NFK, FRAM) to the new `vN` path in their respective GCS buckets
+   - Commits the new `uploads.md` row and pushes an annotated git tag `upload/<env>/v<N>`
+
+   After uploading, open a PR in `firestore-configuration` to point the `mapboxSpriteUrls` for the relevant tenants at the new version path.

--- a/upload_sprites.sh
+++ b/upload_sprites.sh
@@ -1,0 +1,91 @@
+#!/bin/bash
+
+set -e
+
+ENV="${1:?Usage: bash upload_sprites.sh <env>  (env = staging | prod)}"
+[[ "$ENV" =~ ^(staging|prod)$ ]] || { echo "❌ env must be staging|prod"; exit 1; }
+
+NAMESPACES=(AtB Troms NFK FRAM)
+
+get_bucket() {
+  local ns="$1" env="$2"
+  case "$env/$ns" in
+    prod/AtB)      echo "atb-mobility-platform--shared-assets" ;;
+    prod/Troms)    echo "troms-prod--shared-assets" ;;
+    prod/NFK)      echo "nfk-prod--shared-assets" ;;
+    prod/FRAM)     echo "fram-prod-a7850--shared-assets" ;;
+    staging/AtB)   echo "atb-mobility-platform-staging--shared-assets" ;;
+    staging/Troms) echo "troms-staging--shared-assets" ;;
+    staging/NFK)   echo "nfk-staging--shared-assets" ;;
+    staging/FRAM)  echo "fram-staging--shared-assets" ;;
+    *) echo "" ;;
+  esac
+}
+
+MANIFEST="uploads.md"
+OUT_BASE="./generated_sprites"
+
+# --- pre-flight ---
+gcloud auth print-access-token >/dev/null 2>&1 || \
+  { echo "❌ gcloud not authenticated. Run: gcloud auth application-default login"; exit 1; }
+
+[[ -z "$(git status --porcelain)" ]] || \
+  { echo "❌ working tree dirty — commit or stash first (manifest and tag must point at a real commit)"; exit 1; }
+
+git fetch origin --quiet
+BRANCH="$(git rev-parse --abbrev-ref HEAD)"
+git merge-base --is-ancestor HEAD "origin/$BRANCH" 2>/dev/null || \
+  { echo "❌ HEAD not pushed to origin/$BRANCH — push first"; exit 1; }
+
+COMMIT="$(git rev-parse HEAD)"
+SHORT_SHA="$(git rev-parse --short HEAD)"
+UPLOADER="$(git config user.email)"
+TIMESTAMP="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+# --- determine next version (auto-bump per env from manifest) ---
+LAST_VERSION=""
+if [[ -f "$MANIFEST" ]]; then
+  LAST_VERSION=$(awk -F'|' -v env="$ENV" '
+    {
+      gsub(/^ +| +$/, "", $3)
+      gsub(/^ +| +$/, "", $4)
+      if ($3 == env && $4 ~ /^v[0-9]+$/) v=$4
+    }
+    END { if (v) print v }
+  ' "$MANIFEST")
+fi
+if [[ -z "$LAST_VERSION" ]]; then
+  echo "❌ no prior $ENV entry found in $MANIFEST"
+  echo "   Seed it with a baseline row, e.g.:"
+  echo "   | $(date -u +%Y-%m-%dT%H:%M:%SZ) | $ENV | v4 | 0000000 | seed |"
+  exit 1
+fi
+NEXT_NUM=$(( ${LAST_VERSION#v} + 1 ))
+NEXT_VERSION="v${NEXT_NUM}"
+echo "🆕 $ENV: $LAST_VERSION → $NEXT_VERSION"
+
+# --- validate generated_sprites are present ---
+for NAME in "${NAMESPACES[@]}"; do
+  [[ -d "$OUT_BASE/$NAME" ]] || { echo "❌ $OUT_BASE/$NAME missing — run generate_sprites.sh first"; exit 1; }
+done
+
+# --- upload all tenants ---
+echo "☁️  Uploading to $ENV ($NEXT_VERSION)..."
+for NAME in "${NAMESPACES[@]}"; do
+  BUCKET="$(get_bucket "$NAME" "$ENV")"
+  DEST="gs://${BUCKET}/map-assets/${NEXT_VERSION}/"
+  echo "  ➤ $NAME → $DEST"
+  gcloud storage cp "${OUT_BASE}/${NAME}/"*.{png,json} "$DEST"
+done
+
+# --- append manifest row ---
+echo "| $TIMESTAMP | $ENV | $NEXT_VERSION | $SHORT_SHA | $UPLOADER |" >> "$MANIFEST"
+
+# --- commit + tag + push ---
+git add "$MANIFEST"
+git commit -m "chore: upload sprites to $ENV ($NEXT_VERSION)"
+git tag -a "upload/$ENV/$NEXT_VERSION" \
+  -m "Uploaded sprites to $ENV $NEXT_VERSION at $TIMESTAMP (commit $SHORT_SHA, by $UPLOADER)"
+git push --follow-tags
+
+echo "✅ done — tag: upload/$ENV/$NEXT_VERSION"

--- a/uploads.md
+++ b/uploads.md
@@ -1,0 +1,8 @@
+# Sprite uploads
+
+Append-only log. Each row = one upload run (all four tenants uploaded to the same `vN`).
+
+| Timestamp | Env | Version | Commit | Uploader |
+|-----------|-----|---------|--------|----------|
+| 2026-04-28T00:00:00Z | staging | v4 | 0000000 | seed |
+| 2026-04-28T00:00:00Z | prod    | v4 | 0000000 | seed |


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/generate-sprites.yml` — triggers on PRs touching `sprite_assets/**`, detects changed namespaces from diff, regenerates only those sprites via `generate_sprites.sh`, auto-commits result back to PR branch
- Updates `generate_sprites.sh` to accept optional namespace arguments (zero args = all namespaces), replaces `sleep 2` with martin `/health` poll, drops `--restart unless-stopped`, makes curl failures hard errors
- Adds `upload_sprites.sh` — local script to push `generated_sprites/` to per-tenant GCS `*--shared-assets` buckets; auto-bumps version per env from `uploads.md`, uploads all four tenants (AtB, Troms, NFK, FRAM) simultaneously, appends manifest row, commits + creates annotated git tag `upload/<env>/vN`, pushes
- Adds `uploads.md` — append-only markdown table seeded at `v4` for both envs; first real upload bumps to `v5`
- Documents both workflows in `README.md`

## Pre-requisites for upload

- `gcloud` CLI installed and authenticated (`gcloud auth application-default login`)
- Account with `roles/storage.objectAdmin` on target `*--shared-assets` buckets
- After upload: open a PR in `firestore-configuration` pointing `mapboxSpriteUrls` at the new `vN`

## Test plan

- [x] Open a draft PR touching an SVG under `sprite_assets/` — confirm CI detects namespace, regenerates, bot-commits back
- [x] Confirm second CI run (triggered by bot commit) exits as no-op
- [x] Run `bash upload_sprites.sh staging` locally with valid gcloud auth — confirm version bumps, all four staging buckets updated, manifest row appended, tag pushed
- [x] Confirm pre-flight guards work: dirty tree, unpushed HEAD, missing gcloud auth all fail with clear messages

Closes AtB-AS/kundevendt#23228

🤖 Generated with [Claude Code](https://claude.com/claude-code)