### PR TITLE
chore: upload sprites to staging (v5)

### DIFF
--- a/uploads.md
+++ b/uploads.md
@@ -6,3 +6,4 @@ Append-only log. Each row = one upload run (all four tenants uploaded to the sam
 |-----------|-----|---------|--------|----------|
 | 2026-04-28T00:00:00Z | staging | v4 | 0000000 | seed |
 | 2026-04-28T00:00:00Z | prod    | v4 | 0000000 | seed |
+| 2026-05-11T11:11:17Z | staging | v5 | 33c023c | adrian_berg96@hotmail.com |


### PR DESCRIPTION
Sprites already uploaded to GCS at gs://\*-staging--shared-assets/map-assets/v5/. This PR lands the manifest row + version tag.