### PR TITLE
fix: workflow shallow fetch breaks merge base detection

### DIFF
--- a/.github/workflows/generate-sprites.yml
+++ b/.github/workflows/generate-sprites.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Detect changed namespaces
         id: namespaces
         run: |
-          git fetch origin "$GITHUB_BASE_REF" --depth=1
+          git fetch origin "$GITHUB_BASE_REF"
           CHANGED=$(git diff --name-only "origin/$GITHUB_BASE_REF...HEAD" -- 'sprite_assets/' \
             | awk -F/ 'NF>=2 {print $2}' | sort -u | tr '\n' ' ' | xargs)
           echo "changed=$CHANGED" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
Dropping `--depth=1` from the `git fetch` in the Detect changed namespaces step.

**Root cause:** `actions/checkout` runs with `fetch-depth: 0` (full history), then `git fetch origin main --depth=1` adds a shallow marker in `.git/shallow`, blocking ancestry traversal from `origin/main`. When the PR branch was created before the current tip of main, the merge base sits behind the shallow cut — `origin/main...HEAD` finds no merge base and fails.

The `--depth=1` is redundant since full history is already present from the checkout step.