### PR TITLE
chore: upload sprites to prod (v5)

### DIFF
--- a/uploads.md
+++ b/uploads.md
@@ -8,3 +8,4 @@ Append-only log. Each row = one upload run (all four tenants uploaded to the sam
 | 2026-04-28T00:00:00Z | prod    | v4 | 0000000 | seed |
 | 2026-05-11T11:57:03Z | staging | v5 | 687e508 | adrian_berg96@hotmail.com |
 | 2026-05-12T10:22:21Z | staging | v6 | eecca3c | adrian_berg96@hotmail.com |
+| 2026-05-12T13:38:53Z | prod    | v5 | eecca3c | adrian_berg96@hotmail.com |


### PR DESCRIPTION
Sprites uploaded to GCS at `map-assets/v5/` across all prod tenant buckets. This PR lands the manifest row + version tag.